### PR TITLE
Github action to sync files to s3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Upload Website
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: upload to unpublished bucket
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --metadata pdfsource=custom-pdfs --size-only
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_UNPUBLISHED_PRODUCTION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PDF_UPLOADER_PRODUCTION }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PDF_UPLOADER_PRODUCTION }}
+        AWS_REGION: 'eu-west-2'   # optional: defaults to us-east-1
+        SOURCE_DIR: 'files'      # optional: defaults to entire repository
+    - name: upload to published bucket
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --metadata pdfsource=custom-pdfs --size-only
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_PUBLISHED_PRODUCTION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PDF_UPLOADER_PRODUCTION }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PDF_UPLOADER_PRODUCTION }}
+        AWS_REGION: 'eu-west-2'   # optional: defaults to us-east-1
+        SOURCE_DIR: 'files'      # optional: defaults to entire repository


### PR DESCRIPTION
When we push pdfs to main they'll get uploaded to the published and unpublished S3 buckets. You can change the variables in the workflow file to end with `_STAGING` instead of `_PRODUCTION` for testing purposes (and might want to add your branch name to it too.)