### PR TITLE
Invalidate cache on push of this repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,3 +30,22 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PDF_UPLOADER_PRODUCTION }}
         AWS_REGION: 'eu-west-2'   # optional: defaults to us-east-1
         SOURCE_DIR: 'files'      # optional: defaults to entire repository
+    - name: configure AWS credentials for cloudfront invalidation
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PDF_UPLOADER_PRODUCTION}}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PDF_UPLOADER_PRODUCTION }}
+        aws-region: 'eu-west-2'
+    - uses: badsyntax/github-action-aws-cloudfront@master
+      name: Invalidate assets.caselaw.nationalarchives.gov.uk
+      id: invalidate-cloudfront-cache
+      with:
+        distribution-id: ${{ secrets.AWS_ASSETS_DISTRIBUTION_ID }}
+        aws-region: 'eu-west-2'
+        # origin-prefix: ''
+        include-origin-prefix: false
+        invalidate-paths: '/*'
+        # default-root-object: 'index.html'
+
+      # added cache-invalidator to staging/prod github-action-custom-pdf user
+      # added ASSETS_DISTRIBUTION_ID to github secrets for repo


### PR DESCRIPTION
When this repo is pushed, we upload pdfs to S3; we should invalidate the assets.caselaw.nationalarchives.gov.uk cache to ensure that the details are fresh. This is a bit of a sledgehammer; a more finely tuned option would just invalidate the new files.

Presumably the unpublished files are not cached in cloudfront at all.

We might need to also think about invalidating caselaw., since /data.pdf might be cached, but I think we mostly just point at assets these days.

Permissions have already been granted in S3 to the `github-action-custom-pdf` user and a secret added to this github repo.