### PR TITLE
No --acl public-read

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
       run: >
         aws s3 sync files s3://${{ secrets.AWS_S3_BUCKET_PUBLISHED_PRODUCTION }}/
         --no-progress
-        --acl public-read
         --metadata pdfsource=custom-pdfs
         --size-only
     - uses: badsyntax/github-action-aws-cloudfront@master


### PR DESCRIPTION
Uploads to the public bucket were failing with (shortened)


`upload failed: An error occurred (AccessDenied) when calling the PutObject operation: User is not authorized to perform: s3:PutObject on resource because public access control lists (ACLs) are blocked by the BlockPublicAcls block public access setting.`

We needed to set `--acl public-read` when we had ACLs, but we don't any more. (Good.)